### PR TITLE
More folders

### DIFF
--- a/app.R
+++ b/app.R
@@ -361,8 +361,8 @@ server <- function(input, output, session) {
       
       folder_synID <- folders_namedList[[selected_folder]]
       
-      validate(
-        need(length(folder_synID)==1, 'Duplicate folder names detected. Please make sure folders have distinct names.')
+      shiny::validate(
+        shiny::need(length(folder_synID)==1, 'Duplicate folder names detected. Please make sure folders have distinct names.')
       )
       
       # showNotification( folder_synID, duration = NULL, type = "warning")

--- a/app.R
+++ b/app.R
@@ -76,7 +76,7 @@ ui <- dashboardPage(
       style="color:white;",
       spin_flowers(),
       h3("logging in...")
-    )),-
+    )),
     use_notiflix_report(), 
     tabItems(
       # First tab content

--- a/app.R
+++ b/app.R
@@ -74,9 +74,9 @@ ui <- dashboardPage(
     use_waiter(),
     waiter::waiter_show_on_load(html = span(
       style="color:white;",
-      spin_heartbeat(),
+      spin_flowers(),
       h3("logging in...")
-    )),
+    )),-
     use_notiflix_report(), 
     tabItems(
       # First tab content
@@ -224,7 +224,7 @@ server <- function(input, output, session) {
     
     waiter::waiter_update(html = span(
       style="color:white;",
-      spin_heartbeat(),
+      spin_flowers(),
       h3("logging in...")
     ))
     ### logs in 
@@ -235,7 +235,7 @@ server <- function(input, output, session) {
     waiter::waiter_hide()
     waiter::waiter_show(html = span(
       style="color:white;",
-      spin_heartbeat(),
+      spin_flowers(),
       h3(login_msg)
     ))
     
@@ -245,7 +245,7 @@ server <- function(input, output, session) {
     # get_projects_list(synStore_obj)
     waiter::waiter_update(html = span(
       style="color:white;",
-      spin_heartbeat(),
+      spin_flowers(),
       h3("retrieving projects...")
     ))
     
@@ -350,8 +350,13 @@ server <- function(input, output, session) {
       template_type <- as.character(template_type_df$schema_name)
       
       ### progess notif
-      showNotification(id = "processing", "Generating link...", duration = NULL, type = "warning")
+      waiter::waiter_show(html = span(
+        style="color:white;",
+        spin_flowers(),
+        h3("generating manifest...")
+      ))
       
+
       project_synID <- projects_namedList[[selected_project]] ### get synID of selected project
       
       # folder_list <- syn_store$getStorageDatasetsInProject(synStore_obj, project_synID)
@@ -395,7 +400,7 @@ server <- function(input, output, session) {
         })
         
         ### when done remove progress notif
-        removeNotification(id = "processing")
+        waiter::waiter_hide()
       } else {
         ### if the manifest already exists
         manifest_entity <- syn_get(existing_manifestID)
@@ -406,7 +411,7 @@ server <- function(input, output, session) {
         output$text <- renderUI({
           tags$a(href = manifest_url, manifest_url, target = "_blank")
         })
-        removeNotification(id = "processing")
+        waiter::waiter_hide()
       }
     }
   )
@@ -448,7 +453,11 @@ server <- function(input, output, session) {
       
       toggle('text_div2')
       
-      showNotification(id = "processing", "Processing...", duration = NULL, type = "default")
+      waiter::waiter_show(html = span(
+        style="color:white;",
+        spin_flowers(),
+        h3("validating annotations...")
+      ))
       
       if (length(annotation_status) != 0) {
         
@@ -514,12 +523,12 @@ server <- function(input, output, session) {
           ) %>% formatStyle(unlist(column_names),
                             backgroundColor = styleEqual( unlist(error_values), rep("yellow", length(error_values) ) )) ## how to have multiple errors
         })
-        removeNotification(id = "processing")
+        waiter::waiter_hide()
       } else {
         output$text2 <- renderUI({
           HTML("Your metadata is valid!")
         })
-        removeNotification(id = "processing")
+        waiter::waiter_hide()
         ### show submit button
         output$submit <- renderUI({
           actionButton("submitButton", "Submit to Synapse")

--- a/app.R
+++ b/app.R
@@ -16,6 +16,7 @@ library(waiter)
 #########global
 use_condaenv('data_curator_env', required = TRUE)
 reticulate::import("sys")
+reticulate::import('synapseutils')
 
 source_python("synLoginFun.py")
 source_python("metadataModelFuns.py")
@@ -361,7 +362,7 @@ server <- function(input, output, session) {
       folder_synID <- folders_namedList[[selected_folder]]
       
       validate(
-        need(length(folder_synID)==1, 'Duplicate folder names detected. Please make sure folders have distinct names.'),
+        need(length(folder_synID)==1, 'Duplicate folder names detected. Please make sure folders have distinct names.')
       )
       
       # showNotification( folder_synID, duration = NULL, type = "warning")
@@ -372,6 +373,7 @@ server <- function(input, output, session) {
       
       ### if there isn't an existing manifest make a new one 
       if (existing_manifestID == '') {
+        
         file_list <- syn_store$getFilesInStorageDataset(synStore_obj, folder_synID)
         file_namedList <- c()
         for (i in seq_along(file_list)) {

--- a/app.R
+++ b/app.R
@@ -311,16 +311,12 @@ server <- function(input, output, session) {
                      
                      ### gets folders per project
                      # folder_list <- syn_store$getStorageDatasetsInProject(synStore_obj, project_synID)
+                     #TODO: replace multiple queries with one main fileview query and then filter in memory
                      folder_df <- syn_tableQuery(sprintf("select name, id from %s where type = 'folder' and projectId = '%s'", config$main_fileview, project_synID))$asDataFrame()
                      
                      folders_namedList <- setNames(as.list(folder_df$id), folder_df$name)
                      
-                     folder_synID <- folders_namedList[[selected_folder]]
-                     
-                     validate(
-                       need(length(folder_synID)==1, 'Duplicate folder names detected. Please make sure folders have distinct names.'),
-                     )
-                     
+                     folder_names <- names(folders_namedList)
                      
                      ### updates foldernames
                      selectInput(inputId = "dataset", label = "Folder:", choices = folderNames)
@@ -362,7 +358,11 @@ server <- function(input, output, session) {
       
       folders_namedList <- setNames(as.list(folder_df$id), folder_df$name)
       
-      folder_names <- names(folders_namedList)
+      folder_synID <- folders_namedList[[selected_folder]]
+      
+      validate(
+        need(length(folder_synID)==1, 'Duplicate folder names detected. Please make sure folders have distinct names.'),
+      )
       
       # showNotification( folder_synID, duration = NULL, type = "warning")
       

--- a/app.R
+++ b/app.R
@@ -310,12 +310,17 @@ server <- function(input, output, session) {
                      project_synID <- projects_namedList[[selected_project]] ### get synID of selected project
                      
                      ### gets folders per project
-                     folder_list <- syn_store$getStorageDatasetsInProject(synStore_obj, project_synID)
-                     folders_namedList <- c()
-                     for (i in seq_along(folder_list)) {
-                       folders_namedList[folder_list[[i]][[2]]] <- folder_list[[i]][[1]]
-                     }
-                     folderNames <- names(folders_namedList)
+                     # folder_list <- syn_store$getStorageDatasetsInProject(synStore_obj, project_synID)
+                     folder_df <- syn_tableQuery(sprintf("select name, id from %s where type = 'folder' and projectId = '%s'", config$main_fileview, project_synID))$asDataFrame()
+                     
+                     folders_namedList <- setNames(as.list(folder_df$id), folder_df$name)
+                     
+                     folder_synID <- folders_namedList[[selected_folder]]
+                     
+                     validate(
+                       need(length(folder_synID)==1, 'Duplicate folder names detected. Please make sure folders have distinct names.'),
+                     )
+                     
                      
                      ### updates foldernames
                      selectInput(inputId = "dataset", label = "Folder:", choices = folderNames)
@@ -352,12 +357,17 @@ server <- function(input, output, session) {
       
       project_synID <- projects_namedList[[selected_project]] ### get synID of selected project
       
-      folder_list <- syn_store$getStorageDatasetsInProject(synStore_obj, project_synID)
-      folders_namedList <- c()
-      for (i in seq_along(folder_list)) {
-        folders_namedList[folder_list[[i]][[2]]] <- folder_list[[i]][[1]]
-      }
+      # folder_list <- syn_store$getStorageDatasetsInProject(synStore_obj, project_synID)
+      folder_df <- syn_tableQuery(sprintf("select name, id from %s where type = 'folder' and projectId = '%s'", config$main_fileview, project_synID))$asDataFrame()
+      
+      folders_namedList <- setNames(as.list(folder_df$id), folder_df$name)
+      
       folder_synID <- folders_namedList[[selected_folder]]
+      
+      validate(
+        need(length(folder_synID)==1, 'Duplicate folder names detected. Please make sure folders have distinct names.'),
+      )
+      
       # showNotification( folder_synID, duration = NULL, type = "warning")
       
       ### checks if a manifest already exists
@@ -548,13 +558,16 @@ server <- function(input, output, session) {
           selected_project <- input$var
           
           project_synID <- projects_namedList[[selected_project]] ### get synID of selected project
-          folder_list <- syn_store$getStorageDatasetsInProject(synStore_obj, project_synID)
-          folders_namedList <- c()
-          for (i in seq_along(folder_list)) {
-            folders_namedList[folder_list[[i]][[2]]] <- folder_list[[i]][[1]]
-          }
+          # folder_list <- syn_store$getStorageDatasetsInProject(synStore_obj, project_synID)
+          folder_df <- syn_tableQuery(sprintf("select name, id from %s where type = 'folder' and projectId = '%s'", config$main_fileview, project_synID))$asDataFrame()
+          
+          folders_namedList <- setNames(as.list(folder_df$id), folder_df$name)
           
           folder_synID <- folders_namedList[[selected_folder]]
+          
+          validate(
+            need(length(folder_synID)==1, 'Duplicate folder names detected. Please make sure folders have distinct names.'),
+          )
           
           file_list <- syn_store$getFilesInStorageDataset(synStore_obj, folder_synID)
           file_namedList <- c()
@@ -573,12 +586,16 @@ server <- function(input, output, session) {
         
         project_synID <- projects_namedList[[selected_project]] ### get synID of selected project
         
-        folder_list <- syn_store$getStorageDatasetsInProject(synStore_obj, project_synID)
-        folders_namedList <- c()
-        for (i in seq_along(folder_list)) {
-          folders_namedList[folder_list[[i]][[2]]] <- folder_list[[i]][[1]]
-        }
+        # folder_list <- syn_store$getStorageDatasetsInProject(synStore_obj, project_synID)
+        folder_df <- syn_tableQuery(sprintf("select name, id from %s where type = 'folder' and projectId = '%s'", config$main_fileview, project_synID))$asDataFrame()
+        
+        folders_namedList <- setNames(as.list(folder_df$id), folder_df$name)
+        
         folder_synID <- folders_namedList[[selected_folder]]
+        
+        validate(
+          need(length(folder_synID)==1, 'Duplicate folder names detected. Please make sure folders have distinct names.'),
+        )
         
         ### associates metadata with data and returns manifest id
         manifest_id <- syn_store$associateMetadataWithFiles(synStore_obj, "./files/synapse_storage_manifest.csv", folder_synID)
@@ -625,12 +642,16 @@ server <- function(input, output, session) {
         project_synID <- projects_namedList[[selected_project]] ### get synID of selected project
         # folder_synID <- get_folder_synID(synStore_obj, project_synID, selected_folder)
         
-        folder_list <- syn_store$getStorageDatasetsInProject(synStore_obj, project_synID)
-        folders_namedList <- c()
-        for (i in seq_along(folder_list)) {
-          folders_namedList[folder_list[[i]][[2]]] <- folder_list[[i]][[1]]
-        }
+        # folder_list <- syn_store$getStorageDatasetsInProject(synStore_obj, project_synID)
+        folder_df <- syn_tableQuery(sprintf("select name, id from %s where type = 'folder' and projectId = '%s'", config$main_fileview, project_synID))$asDataFrame()
+        
+        folders_namedList <- setNames(as.list(folder_df$id), folder_df$name)
+        
         folder_synID <- folders_namedList[[selected_folder]]
+        
+        validate(
+          need(length(folder_synID)==1, 'Duplicate folder names detected. Please make sure folders have distinct names.'),
+        )
         
         ### associates metadata with data and returns manifest id
         manifest_id <- syn_store$associateMetadataWithFiles(synStore_obj, "./files/synapse_storage_manifest.csv", folder_synID)

--- a/app.R
+++ b/app.R
@@ -362,11 +362,7 @@ server <- function(input, output, session) {
       
       folders_namedList <- setNames(as.list(folder_df$id), folder_df$name)
       
-      folder_synID <- folders_namedList[[selected_folder]]
-      
-      validate(
-        need(length(folder_synID)==1, 'Duplicate folder names detected. Please make sure folders have distinct names.'),
-      )
+      folder_names <- names(folders_namedList)
       
       # showNotification( folder_synID, duration = NULL, type = "warning")
       

--- a/app.R
+++ b/app.R
@@ -316,7 +316,7 @@ server <- function(input, output, session) {
                      
                      folders_namedList <- setNames(as.list(folder_df$id), folder_df$name)
                      
-                     folder_names <- names(folders_namedList)
+                     folderNames <- names(folders_namedList)
                      
                      ### updates foldernames
                      selectInput(inputId = "dataset", label = "Folder:", choices = folderNames)

--- a/www/config.json
+++ b/www/config.json
@@ -1,5 +1,6 @@
 {
   "manifest_schemas": [
       {"display_name": "Genomics Assay", "schema_name": "GenomicsAssay", "type": "assay"}
-  ]
+  ],
+  "main_fileview" : "syn16858331"
 }


### PR DESCRIPTION
Added functionality:

`waiters` on the get manifest and validate manifest actions to prevent more than one click of the respective buttons, and as a more pronounced status update for user
modified the way the app looks for folders - now it will look for _every_ folder in the selected project. This is better for NF, where we have data often beyond the top-level of folders. However, it introduces a new problem: what if the user has data across many subfolders that they'd like to annotate at once (there are a few examples of this in NF)? We'd need to add support for selecting multiple folders, enable adding files by entire project, or by enabling recursive identification of files. This can probably be pretty easily achieved with `synapseutils.walk.walk()`