### PR TITLE
Revert "v1.0.1 schema"

### DIFF
--- a/NF.jsonld
+++ b/NF.jsonld
@@ -12624,13 +12624,13 @@
             },
             "schema:rangeIncludes": [
                 {
+                    "@id": "bts:Ai"
+                },
+                {
                     "@id": "bts:Bashscript"
                 },
                 {
                     "@id": "bts:Bedgraph"
-                },
-                {
-                    "@id": "bts:Ai"
                 },
                 {
                     "@id": "bts:Idx"
@@ -12870,19 +12870,10 @@
                     "@id": "bts:SDAT"
                 },
                 {
-                    "@id": "bts:Nii"
-                },
-                {
                     "@id": "bts:PAR"
                 },
                 {
                     "@id": "bts:REC"
-                },
-                {
-                    "@id": "bts:Hdr"
-                },
-                {
-                    "@id": "bts:Img"
                 },
                 {
                     "@id": "bts:Sf"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,4 @@
 
-**Please note, "releases" only pertain to changes in the JSON-LD schema file.**
-
 # NF Data Curator App
 
 ## Shiny app configuration


### PR DESCRIPTION
Reverts nf-osi/NF_data_curator#97

There is an issue with validation, and wondering if some change to the schema broke this, so testing here. 