### PR TITLE
Fix deployment

### DIFF
--- a/.github/workflows/shinyapps_deploy.yml
+++ b/.github/workflows/shinyapps_deploy.yml
@@ -52,12 +52,10 @@ jobs:
           source .venv/bin/activate
           # use 'poetry' to install schematic from the develop branch 
           pip3 install poetry
-          git clone --single-branch --branch develop https://github.com/Sage-Bionetworks/schematic.git
+          git clone --single-branch --branch synapse-version-pin https://github.com/Sage-Bionetworks/schematic.git
           cd schematic
           poetry build
           pip3 install dist/schematicpy-1.0.0-py3-none-any.whl
-          pip3 uninstall synapseclient
-          pip3 install synapseclient==2.5.0
       - name: Set Configurations for Schematic
         shell: bash
         run: |

--- a/.github/workflows/shinyapps_deploy.yml
+++ b/.github/workflows/shinyapps_deploy.yml
@@ -52,7 +52,7 @@ jobs:
           source .venv/bin/activate
           # use 'poetry' to install schematic from the develop branch 
           pip3 install poetry
-          git clone --single-branch --branch synapse-version-pin https://github.com/Sage-Bionetworks/schematic.git
+          git clone --single-branch --branch develop https://github.com/Sage-Bionetworks/schematic.git
           cd schematic
           poetry build
           pip3 install dist/schematicpy-1.0.0-py3-none-any.whl

--- a/.github/workflows/shinyapps_deploy.yml
+++ b/.github/workflows/shinyapps_deploy.yml
@@ -56,6 +56,8 @@ jobs:
           cd schematic
           poetry build
           pip3 install dist/schematicpy-1.0.0-py3-none-any.whl
+          pip3 uninstall synapseclient
+          pip3 install synapseclient==2.5.0
       - name: Set Configurations for Schematic
         shell: bash
         run: |

--- a/.github/workflows/shinyapps_deploy.yml
+++ b/.github/workflows/shinyapps_deploy.yml
@@ -88,8 +88,8 @@ jobs:
           refName <- Sys.getenv("GITHUB_REF_NAME")
           repo <- Sys.getenv("GITHUB_REPOSITORY")
           appName <- strsplit(repo, "/")[[1]][2]
-          # if tag is v*.*.*, deploy to prod, otherwise to staging
-          if (!grepl("v[0-9]+.[0-9]+.[0-9]+", refName)) {
+          # if tag is release-*.*.*, deploy to prod, otherwise to staging
+          if (!grepl("release-[0-9]+.[0-9]+.[0-9]+", refName)) {
             appName <- paste(appName, "staging", sep = "-")
           }
           rsConnectUser <- "${{ secrets.RSCONNECT_USER }}"


### PR DESCRIPTION
the deployment workflow was looking for tagged releases as "vX.X.X" to deploy, but should be looking for release-X.X.X, I think I might have inadvertently pulled in the vX.X.X part from upstream. 

Either way, I think this should correct it, so that releases tagged release-1.2.3 will be deployed to production (desired), rather than to staging (not desired). 

