### PR TITLE
add support for manifest_record_type param

### DIFF
--- a/server.R
+++ b/server.R
@@ -404,8 +404,8 @@ shinyServer(function(input, output, session) {
         synStore_obj,
         "./tmp/synapse_storage_manifest.csv", folder_synID(),
         useSchemaLabel = FALSE,
-        hideBlanks = TRUE
-        
+        hideBlanks = TRUE,
+        manifest_record_type = 'table'
       )
       manifest_path <- tags$a(href = paste0("synapse.org/#!Synapse:", manifest_id), manifest_id, target = "_blank")
 


### PR DESCRIPTION
Resolves a bug where this parameter is not found when trying to submit to synapse: https://github.com/Sage-Bionetworks/schematic/blob/ecf9d2013cbe4ebdea0cd887823ff8f45634405d/schematic/store/synapse.py#L599

`2022-04-06T00:40:43.351267+00:00 shinyapps[5711947]: Warning: Error in py_call_impl: TypeError: associateMetadataWithFiles() missing 1 required positional argument: 'manifest_record_type'`