### PR TITLE
Update to latest release of nf-metadata-dctionary

### DIFF
--- a/schematic_config.yml
+++ b/schematic_config.yml
@@ -19,7 +19,7 @@ manifest:
 
 model:
   input:
-    download_url: 'https://raw.githubusercontent.com/nf-osi/nf-metadata-dictionary/5c362431fd52a2890b63d65114bc9b3a9a26e11e/NF.jsonld' # url to download JSON-LD data model
+    download_url: 'https://raw.githubusercontent.com/nf-osi/nf-metadata-dictionary/v4.1.0/NF.jsonld' # url to download JSON-LD data model
     location: 'data-models/NF.jsonld' # path to JSON-LD data model
     file_type: 'local' 
     


### PR DESCRIPTION
No functional change, as it will resolve to the same commit, but this link points to the latest tagged release of the schema, v4.1.0.