### PR TITLE
Add CI workflow with model repo, related to to issue #122

### DIFF
--- a/.github/workflows/update_model_dev.yml
+++ b/.github/workflows/update_model_dev.yml
@@ -1,0 +1,49 @@
+name: Update source model for dev
+
+# Update model download_url in `schematic_config.yml`
+# to point to new source URL in `develop` branch. 
+on:
+  # Note: can also run this workflow manually from the Actions tab
+  workflow_dispatch:
+    inputs:
+      source:
+        description: 'URL of new source'     
+        required: true
+
+env:
+  SOURCE_URL: ${{ github.event.inputs.source }}
+
+jobs:
+  update-model:
+    runs-on: ubuntu-latest
+
+    steps:
+      # Check out development branch under $GITHUB_WORKSPACE
+      - uses: actions/checkout@v3
+        with:
+          ref: develop
+          
+      # Check steps matter more for rare occasions of manual input
+      # vs. programmatic dispatches
+      - name: Check that source link works
+        run: wget $SOURCE_URL -O model.json
+
+      # Check format as can be easy to not grab the actual raw.github URL
+      - name: Check is JSON
+        run: cat model.json | python -m simplejson.tool > validated.json
+        
+      - name: Update config
+        uses: mikefarah/yq@master
+        with:
+          cmd: yq -i '.model.input.download_url = strenv(SOURCE_URL)' schematic_config.yml
+        
+      - name: Commit files
+        run: |
+          git config user.email "nf-osi@sagebionetworks.org"
+          git config user.name "nf-osi[bot]"
+          git commit -m "Update model source in config" -a
+    
+      - name: Push changes
+        uses: ad-m/github-push-action@master
+        with:
+          branch: ${{ github.ref }}

--- a/.github/workflows/update_model_dev.yml
+++ b/.github/workflows/update_model_dev.yml
@@ -22,6 +22,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           ref: develop
+          persist-credentials: false
           
       # Check steps matter more for rare occasions of manual input
       # vs. programmatic dispatches
@@ -39,11 +40,13 @@ jobs:
         
       - name: Commit files
         run: |
-          git config user.email "nf-osi@sagebionetworks.org"
-          git config user.name "nf-osi[bot]"
+          git config user.email "57509804+nfosi-service@users.noreply.github.com"
+          git config user.name "nfosi-service"
           git commit -m "Update model source in config" -a
     
       - name: Push changes
         uses: ad-m/github-push-action@master
         with:
           branch: ${{ github.ref }}
+          github_token: ${{ secrets.SERVICE_TOKEN }}
+


### PR DESCRIPTION
@allaway You can see the working chained workflows here:

- https://github.com/gf-dcc/data_curator/actions/runs/2332796101 (update model URL in config)
- https://github.com/gf-dcc/data_curator/actions/runs/2332798496 (shiny deploy triggered by above)

**This is currently a draft because I need to confirm/resolve two things for NF:**

1. For workflows to trigger other workflows, one needs to use a PAT instead of the default action token. See https://github.com/ad-m/github-push-action/issues/32. For GF, I set up a bot account, same idea as https://github.com/google-github-actions-bot.
2. The PAT needs to have repo scope and be available to this repo -- so we can use REPO_PAT already used for shiny-deploy or set up something new. Once that's confirmed, the workflow can refer to the correct secret.