### PR TITLE
Update production

### DIFF
--- a/.github/workflows/custom_shinyapps_deploy .yml
+++ b/.github/workflows/custom_shinyapps_deploy .yml
@@ -1,4 +1,4 @@
-# Pushes to main
+# Pushes to production
 #              \__#1 deploy w/ SCHEMATIC_PIN --> NF_data_curator (prod)
 #
 # Pushes to develop
@@ -14,7 +14,7 @@ name: custom-shiny-deploy
 on:
   push:
     branches:
-      - main
+      - production
       - develop
       - edge
     paths-ignore:
@@ -60,7 +60,7 @@ jobs:
           source .venv/bin/activate
           # use 'poetry' to install schematic dev schematic
           # If commit is tagged for release or in main branch, install schematic from pypi
-          if [[ $GITHUB_REF_NAME == main ]] || [[ $GITHUB_REF_NAME == develop ]]; then
+          if [[ $GITHUB_REF_NAME == production ]] || [[ $GITHUB_REF_NAME == develop ]]; then
             echo Deploying with pypi version of schematic==${{ env.SCHEMATIC_PIN }}
             git clone --single-branch --branch main https://github.com/Sage-Bionetworks/schematic.git
             cp schematic_config.yml schematic/config.yml
@@ -110,7 +110,7 @@ jobs:
           repo <- Sys.getenv("GITHUB_REPOSITORY")
           appName <- strsplit(repo, "/")[[1]][2]
           refName <- Sys.getenv("GITHUB_REF_NAME")
-          if (refName == "main" || grepl("v[0-9]+.[0-9]+.[0-9]+", refName)) {
+          if (refName == "production" || grepl("v[0-9]+.[0-9]+.[0-9]+", refName)) {
             message("Deploying production instance: ", appName)
           } else if (refName == "develop") {
             appName <- paste(appName, "staging", sep = "-")

--- a/.github/workflows/custom_shinyapps_deploy .yml
+++ b/.github/workflows/custom_shinyapps_deploy .yml
@@ -1,0 +1,136 @@
+# Pushes to main
+#              \__#1 deploy w/ SCHEMATIC_PIN --> NF_data_curator (prod)
+#
+# Pushes to develop
+#              \__#2 deploy w/ SCHEMATIC_PIN --> NF_data_curator-staging
+# Staging deploys are for staging of regular releases of data model
+#
+# Pushes to edge
+#               \__#3 deploy w/ schematic `develop` on GH --> NF_data_curator-edge
+# Edge deploys are for checking new schematic development features
+
+name: custom-shiny-deploy
+
+on:
+  push:
+    branches:
+      - main
+      - develop
+      - edge
+    paths-ignore:
+      - '.github/ISSUE_TEMPLATE/**'
+      - '**/*.md'
+      - '**/.gitignore'
+
+env: 
+  # Known stable and tested version of schematic used with prod and staging DCA
+  SCHEMATIC_PIN: 22.11.3
+  
+jobs:
+  shiny-deploy:
+    runs-on: ubuntu-latest
+    # This image seems to be based on rocker/r-ver which in turn is based on debian
+    container: rocker/rstudio:4.1.2
+    env:
+      # This should not be necessary for installing from public repo's however remotes::install_github() fails without it.
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+
+    steps:
+      - name: Install System Dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y pip python3.8-venv libcurl4-openssl-dev
+      - uses: actions/checkout@v2
+      - uses: r-lib/actions/setup-pandoc@v1
+
+      - name: Create and Activate Python Virtual Environment
+        shell: bash
+        run: |
+          python3 -m venv .venv
+          chmod 755 .venv/bin/activate
+          source .venv/bin/activate
+      - name: Install R Packages Dependencies
+        run: |
+          R -f install-pkgs.R
+
+      - name: Install Schematic
+        shell: bash
+        run: |
+          # has to activate each bash step
+          source .venv/bin/activate
+          # use 'poetry' to install schematic dev schematic
+          # If commit is tagged for release or in main branch, install schematic from pypi
+          if [[ $GITHUB_REF_NAME == main ]] || [[ $GITHUB_REF_NAME == develop ]]; then
+            echo Deploying with pypi version of schematic==${{ env.SCHEMATIC_PIN }}
+            git clone --single-branch --branch main https://github.com/Sage-Bionetworks/schematic.git
+            cp schematic_config.yml schematic/config.yml
+            cd schematic
+            pip3 install schematicpy==${{ env.SCHEMATIC_PIN }}
+          else
+            pip3 install poetry
+            echo Deploying with develop branch of schematic from github
+            git clone --single-branch --branch develop https://github.com/Sage-Bionetworks/schematic.git
+            cp schematic_config.yml schematic/config.yml
+            cd schematic
+            poetry build
+            pip3 install dist/schematicpy-1.0.0-py3-none-any.whl
+          fi
+
+      - name: Set Configurations for Schematic
+        shell: bash
+        run: |
+          # write out configuration files using github secrets
+          echo "${{ secrets.SCHEMATIC_SYNAPSE_CONFIG }}" > .synapseConfig
+          echo "${{ secrets.SCHEMATIC_SERVICE_ACCT_CREDS }}" > schematic_service_account_creds.json
+          echo "${{ secrets.SCHEMATIC_CREDS_PATH }}" > credentials.json
+          echo "${{ secrets.SCHEMATIC_TOKEN_PICKLE }}" | base64 -d > token.pickle
+
+      - name: Set Configurations for Data Model
+        shell: bash
+        run: |
+          source .venv/bin/activate
+          # download the data models and create config.json
+          python3 .github/config_schema.py \
+            -c schematic_config.yml \
+            --service_repo 'Sage-Bionetworks/schematic' # \
+            # --overwrite ##manually define config file
+
+      - name: zip virtual env
+        shell: bash
+        # ShinyApps has a limit of 7000 files, far exceeded by the many Python dependencies
+        # that this app' has.  As a workaround we zip the virtual environment and later
+        # unzip it in 'global.R'
+        run: |
+          zip -rm .venv.zip .venv
+      
+      - name: Authorize and deploy app
+        shell: Rscript {0}
+        run: |
+          # if there is a tag, 'refName' will be tag name
+          repo <- Sys.getenv("GITHUB_REPOSITORY")
+          appName <- strsplit(repo, "/")[[1]][2]
+          refName <- Sys.getenv("GITHUB_REF_NAME")
+          if (refName == "main" || grepl("v[0-9]+.[0-9]+.[0-9]+", refName)) {
+            message("Deploying production instance: ", appName)
+          } else if (refName == "develop") {
+            appName <- paste(appName, "staging", sep = "-")
+            message("Deploying staging instance: ", appName)
+          } else {
+            appName <- paste(appName, "edge", sep = "-")
+            message("Deploying edge instance: ", appName)
+          }
+          rsConnectUser <- "${{ secrets.RSCONNECT_USER }}"
+          rsConnectToken <- "${{ secrets.RSCONNECT_TOKEN }}"
+          rsConnectSecret <- "${{ secrets.RSCONNECT_SECRET }}"
+          # create config file
+          config <- "CLIENT_ID: ${{ secrets.OAUTH_CLIENT_ID }}"
+          config <- c(config, "CLIENT_SECRET: ${{ secrets.OAUTH_CLIENT_SECRET }}")
+          appUrl <- sprintf("https://%s.shinyapps.io/%s", rsConnectUser, appName)
+          config <- c(config, sprintf("APP_URL: %s", appUrl))
+          configFileConn <- file("oauth_config.yml")
+          tryCatch(
+            writeLines(config, configFileConn),
+            finally=close(configFileConn)
+          )
+          rsconnect::setAccountInfo(rsConnectUser, rsConnectToken, rsConnectSecret)
+          rsconnect::deployApp(appName = appName)

--- a/.github/workflows/update_model_dev.yml
+++ b/.github/workflows/update_model_dev.yml
@@ -15,7 +15,7 @@ env:
 
 jobs:
   update-model:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
       # Check out development branch under $GITHUB_WORKSPACE

--- a/schematic_config.yml
+++ b/schematic_config.yml
@@ -19,7 +19,7 @@ manifest:
 model:
   input:
     # if both 'download_url' and 'repo' present, `repo` will be used
-    download_url: 'https://raw.githubusercontent.com/nf-osi/nf-metadata-dictionary/v6.2.2/NF.jsonld' # url to download JSON-LD data model
+    download_url: 'https://raw.githubusercontent.com/nf-osi/nf-metadata-dictionary/v6.2.3/NF.jsonld' # url to download JSON-LD data model
     #repo: 'nf-osi/nf-metadata-dictionary/v6.2.0' # data model repo url (<repo-owner>/<repo-name>/<version/branch>), version or branch is optional
     location: 'data-models/NF.jsonld' # path to JSON-LD data model
     file_type: 'local'

--- a/schematic_config.yml
+++ b/schematic_config.yml
@@ -19,7 +19,7 @@ manifest:
 model:
   input:
     # if both 'download_url' and 'repo' present, `repo` will be used
-    download_url: 'https://raw.githubusercontent.com/nf-osi/nf-metadata-dictionary/v6.2.4/NF.jsonld' # url to download JSON-LD data model
+    download_url: 'https://raw.githubusercontent.com/nf-osi/nf-metadata-dictionary/v6.2.5/NF.jsonld' # url to download JSON-LD data model
     #repo: 'nf-osi/nf-metadata-dictionary/v6.2.0' # data model repo url (<repo-owner>/<repo-name>/<version/branch>), version or branch is optional
     location: 'data-models/NF.jsonld' # path to JSON-LD data model
     file_type: 'local'

--- a/schematic_config.yml
+++ b/schematic_config.yml
@@ -19,7 +19,7 @@ manifest:
 model:
   input:
     # if both 'download_url' and 'repo' present, `repo` will be used
-    download_url: 'https://raw.githubusercontent.com/nf-osi/nf-metadata-dictionary/v6.2.1/NF.jsonld' # url to download JSON-LD data model
+    download_url: 'https://raw.githubusercontent.com/nf-osi/nf-metadata-dictionary/v6.2.2/NF.jsonld' # url to download JSON-LD data model
     #repo: 'nf-osi/nf-metadata-dictionary/v6.2.0' # data model repo url (<repo-owner>/<repo-name>/<version/branch>), version or branch is optional
     location: 'data-models/NF.jsonld' # path to JSON-LD data model
     file_type: 'local'

--- a/schematic_config.yml
+++ b/schematic_config.yml
@@ -19,7 +19,7 @@ manifest:
 model:
   input:
     # if both 'download_url' and 'repo' present, `repo` will be used
-    download_url: 'https://raw.githubusercontent.com/nf-osi/nf-metadata-dictionary/v6.2.7/NF.jsonld' # url to download JSON-LD data model
+    download_url: 'https://raw.githubusercontent.com/nf-osi/nf-metadata-dictionary/v6.2.8/NF.jsonld' # url to download JSON-LD data model
     #repo: 'nf-osi/nf-metadata-dictionary/v6.2.0' # data model repo url (<repo-owner>/<repo-name>/<version/branch>), version or branch is optional
     location: 'data-models/NF.jsonld' # path to JSON-LD data model
     file_type: 'local'

--- a/schematic_config.yml
+++ b/schematic_config.yml
@@ -19,7 +19,7 @@ manifest:
 model:
   input:
     # if both 'download_url' and 'repo' present, `repo` will be used
-    download_url: 'https://raw.githubusercontent.com/nf-osi/nf-metadata-dictionary/v6.2.3/NF.jsonld' # url to download JSON-LD data model
+    download_url: 'https://raw.githubusercontent.com/nf-osi/nf-metadata-dictionary/v6.2.4/NF.jsonld' # url to download JSON-LD data model
     #repo: 'nf-osi/nf-metadata-dictionary/v6.2.0' # data model repo url (<repo-owner>/<repo-name>/<version/branch>), version or branch is optional
     location: 'data-models/NF.jsonld' # path to JSON-LD data model
     file_type: 'local'

--- a/schematic_config.yml
+++ b/schematic_config.yml
@@ -4,7 +4,6 @@ definitions:
   creds_path: 'credentials.json'
   token_pickle: 'token.pickle'
   service_acct_creds: 'schematic_service_account_creds.json'
-
 synapse:
   master_fileview: 'syn16858331'
   manifest_folder: 'manifests'
@@ -12,21 +11,18 @@ synapse:
   token_creds: 'syn21088684'
   service_acct_creds: 'syn25171627'
 manifest:
-
   # if making many manifests, just include name prefix
   title: 'NF'
   # to make all manifests enter only 'all manifests'
   data_type:
     - 'NF'
-
 model:
   input:
     # if both 'download_url' and 'repo' present, `repo` will be used
-    download_url: 'https://raw.githubusercontent.com/nf-osi/nf-metadata-dictionary/v.6.2.0/NF.jsonld' # url to download JSON-LD data model
+    download_url: 'https://raw.githubusercontent.com/nf-osi/nf-metadata-dictionary/v6.2.1/NF.jsonld' # url to download JSON-LD data model
     #repo: 'nf-osi/nf-metadata-dictionary/v6.2.0' # data model repo url (<repo-owner>/<repo-name>/<version/branch>), version or branch is optional
     location: 'data-models/NF.jsonld' # path to JSON-LD data model
     file_type: 'local'
-    
 style:
   google_manifest:
     req_bg_color:

--- a/schematic_config.yml
+++ b/schematic_config.yml
@@ -19,7 +19,7 @@ manifest:
 model:
   input:
     # if both 'download_url' and 'repo' present, `repo` will be used
-    download_url: 'https://raw.githubusercontent.com/nf-osi/nf-metadata-dictionary/v6.2.5/NF.jsonld' # url to download JSON-LD data model
+    download_url: 'https://raw.githubusercontent.com/nf-osi/nf-metadata-dictionary/v6.2.6/NF.jsonld' # url to download JSON-LD data model
     #repo: 'nf-osi/nf-metadata-dictionary/v6.2.0' # data model repo url (<repo-owner>/<repo-name>/<version/branch>), version or branch is optional
     location: 'data-models/NF.jsonld' # path to JSON-LD data model
     file_type: 'local'

--- a/schematic_config.yml
+++ b/schematic_config.yml
@@ -19,7 +19,7 @@ manifest:
 model:
   input:
     # if both 'download_url' and 'repo' present, `repo` will be used
-    download_url: 'https://raw.githubusercontent.com/nf-osi/nf-metadata-dictionary/v6.2.6/NF.jsonld' # url to download JSON-LD data model
+    download_url: 'https://raw.githubusercontent.com/nf-osi/nf-metadata-dictionary/v6.2.7/NF.jsonld' # url to download JSON-LD data model
     #repo: 'nf-osi/nf-metadata-dictionary/v6.2.0' # data model repo url (<repo-owner>/<repo-name>/<version/branch>), version or branch is optional
     location: 'data-models/NF.jsonld' # path to JSON-LD data model
     file_type: 'local'

--- a/server.R
+++ b/server.R
@@ -402,7 +402,9 @@ shinyServer(function(input, output, session) {
         metadataManifestPath = "./tmp/synapse_storage_manifest.csv",
         datasetId = folder_synID(),
         manifest_record_type = "entity",
-        restrict_manifest = FALSE
+        restrict_manifest = FALSE,
+        useSchemaLabel = FALSE,
+        hideBlanks = TRUE
 
       )
       manifest_path <- tags$a(href = paste0("https://www.synapse.org/#!Synapse:", manifest_id), manifest_id, target = "_blank")
@@ -439,7 +441,9 @@ shinyServer(function(input, output, session) {
         metadataManifestPath = "./tmp/synapse_storage_manifest.csv",
         datasetId = folder_synID(),
         manifest_record_type = "entity",
-        restrict_manifest = FALSE
+        restrict_manifest = FALSE,
+        useSchemaLabel = FALSE,
+        hideBlanks = TRUE
       )
       manifest_path <- tags$a(href = paste0("https://www.synapse.org/#!Synapse:", manifest_id), manifest_id, target = "_blank")
 

--- a/www/config.json
+++ b/www/config.json
@@ -5,7 +5,6 @@
       {"display_name": "RNA Sequencing Assay", "schema_name": "RNASeqTemplate", "type": "file"},
       {"display_name": "Single-cell RNA Sequencing Assay", "schema_name": "ScRNASeqTemplate", "type": "file"},
       {"display_name": "Epigenetics Assay", "schema_name": "EpigeneticsAssayTemplate", "type": "file"},
-      {"display_name": "PDX Genomics Assay", "schema_name": "PdxGenomicsAssayTemplate", "type": "file"},
       {"display_name": "Other Genomics Assay", "schema_name": "GenomicsAssayTemplate", "type": "file"},
       {"display_name": "Other Genomics Assay (Extended)", "schema_name": "GenomicsAssayTemplateExtended", "type": "file"},
       {"display_name": "Imaging Assay", "schema_name": "ImagingAssayTemplate", "type": "file"},

--- a/www/config.json
+++ b/www/config.json
@@ -18,7 +18,8 @@
       {"display_name": "Processed/Aligned Sequencing Reads", "schema_name": "ProcessedAlignedReadsTemplate", "type": "file"},
       {"display_name": "Processed Variant Calls", "schema_name": "ProcessedVariantCallsTemplate", "type": "file"},
       {"display_name": "Processed Expression Data", "schema_name": "ProcessedExpressionTemplate", "type": "file"},
-      {"display_name": "FACS Template", "schema_name": "FlowCytometryTemplate", "type": "file"}
+      {"display_name": "FACS Template", "schema_name": "FlowCytometryTemplate", "type": "file"},
+      {"display_name": "DLS Template", "schema_name": "DynamicLightScatteringTemplate", "type": "file"}
     ],
   "main_fileview" : "syn16858331",
   "community" : "NF",

--- a/www/config.json
+++ b/www/config.json
@@ -19,7 +19,7 @@
       {"display_name": "Processed Variant Calls", "schema_name": "ProcessedVariantCallsTemplate", "type": "file"},
       {"display_name": "Processed Expression Data", "schema_name": "ProcessedExpressionTemplate", "type": "file"},
       {"display_name": "FACS Template", "schema_name": "FlowCytometryTemplate", "type": "file"},
-      {"display_name": "DLS Template", "schema_name": "DynamicLightScatteringTemplate", "type": "file"}
+      {"display_name": "Light Scattering Assay", "schema_name": "LightScatteringAssayTemplate", "type": "file"}
     ],
   "main_fileview" : "syn16858331",
   "community" : "NF",

--- a/www/config.json
+++ b/www/config.json
@@ -17,7 +17,8 @@
       {"display_name": "Clinical Assay Template", "schema_name": "ClinicalAssayTemplate", "type": "file"},
       {"display_name": "Processed/Aligned Sequencing Reads", "schema_name": "ProcessedAlignedReadsTemplate", "type": "file"},
       {"display_name": "Processed Variant Calls", "schema_name": "ProcessedVariantCallsTemplate", "type": "file"},
-      {"display_name": "Processed Expression Data", "schema_name": "ProcessedExpressionTemplate", "type": "file"}
+      {"display_name": "Processed Expression Data", "schema_name": "ProcessedExpressionTemplate", "type": "file"},
+      {"display_name": "FACS Template", "schema_name": "FlowCytometryTemplate", "type": "file"}
     ],
   "main_fileview" : "syn16858331",
   "community" : "NF",


### PR DESCRIPTION
Mainly:

- **Workflow** with new deploy strategy that maps branches to app instances somewhat differently; also schematic has been pinned to latest real pypi release, which seems stable enough (though I've only tested generation and submission with one template on [staging](https://sagebio.shinyapps.io/NF_data_curator-staging/)). We disable the default `shiny-deploy.yml` as seen in https://github.com/nf-osi/NF_data_curator/actions/workflows/shinyapps_deploy.yml, and `custom-deploy-shiny.yml` has been running fine as seen with `develop` and `edge` in [latest Action runs](https://github.com/nf-osi/NF_data_curator/actions). Note that tagged releases are no longer required (ignored) for deployment to production -- if this is desired, can update wf again.
- **Workflow** handling releases by data model repo explicitly pinned to 20.04 (because GitHub updated `ubuntu-latest` runner to mean 22.04, which broke stuff as seen [here](https://github.com/nf-osi/NF_data_curator/actions/runs/3587133524/jobs/6037132521)). 
- Surface new **templates** and **terms** in production.