### PR TITLE
Update to latest pip version for edge testing

### DIFF
--- a/.github/workflows/custom_shinyapps_deploy.yml
+++ b/.github/workflows/custom_shinyapps_deploy.yml
@@ -25,7 +25,7 @@ on:
 env: 
   # PIN=known stable and tested version of schematic used with prod and staging DCA
   SCHEMATIC_PIN: 23.1.1
-  SCHEMATIC_NEXT: 23.1.1
+  SCHEMATIC_NEXT: 24.1.1
 
 jobs:
   shiny-deploy:


### PR DESCRIPTION
@anngvu, I am trying to see if we can resolve @cconrad8's issue here (https://sagebionetworks.slack.com/archives/C6KQHAGJX/p1706802238952239)

The app is failing with this error: 

```
2024-02-01T16:22:26.338985+00:00 shinyapps[5727796]: Error in use_python(python, required = required) : 
2024-02-01T16:22:26.344971+00:00 shinyapps[5727796]:   Specified version of python '/srv/connect/apps/NF_data_curator/.venv/bin/python' does not exist.
```

I am wondering if a simple upgrade to the latest pypi version of schematic might fix the issue. I don't believe it will, but worth a test. 