### PR TITLE
Update deployment

### DIFF
--- a/.github/workflows/custom_shinyapps_deploy.yml
+++ b/.github/workflows/custom_shinyapps_deploy.yml
@@ -40,13 +40,13 @@ jobs:
       - name: Install System Dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y pip python3.8-venv libcurl4-openssl-dev
+          sudo apt-get install -y pip python3.10-venv libcurl4-openssl-dev
       - uses: actions/checkout@v4
       
       - name: Create and Activate Python Virtual Environment
         shell: bash
         run: |
-          python3 -m venv .venv
+          python3.10 -m venv .venv
           chmod 755 .venv/bin/activate
           source .venv/bin/activate
       - name: Install R Packages Dependencies

--- a/.github/workflows/custom_shinyapps_deploy.yml
+++ b/.github/workflows/custom_shinyapps_deploy.yml
@@ -24,7 +24,7 @@ on:
 
 env: 
   # PIN=known stable and tested version of schematic used with prod and staging DCA
-  SCHEMATIC_PIN: 23.1.1
+  SCHEMATIC_PIN: 23.6.3
   SCHEMATIC_NEXT: 24.1.1
 
 jobs:

--- a/.github/workflows/custom_shinyapps_deploy.yml
+++ b/.github/workflows/custom_shinyapps_deploy.yml
@@ -31,7 +31,7 @@ jobs:
   shiny-deploy:
     runs-on: ubuntu-latest
     # This image seems to be based on rocker/r-ver which in turn is based on debian
-    container: rocker/rstudio:4.1.2
+    container: rocker/rstudio:4.3
     env:
       # This should not be necessary for installing from public repo's however remotes::install_github() fails without it.
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}

--- a/install-pkgs.R
+++ b/install-pkgs.R
@@ -38,7 +38,8 @@ gh <- c(
 # The binary package distributions from R Studio dramatically speed up installation time
 # For Ubuntu 18.04 (Bionic) it's https://packagemanager.rstudio.com/all/__linux__/bionic/latest
 # For Ubuntu 20.04 (Focal)  it's https://packagemanager.rstudio.com/all/__linux__/focal/latest
-options(repos = c(REPO_NAME = "https://packagemanager.rstudio.com/all/__linux__/focal/latest", getOption("repos")))
+# For Ubuntu 22.04 (Jammy)  it's https://packagemanager.rstudio.com/all/__linux__/jammy/latest
+options(repos = c(REPO_NAME = "https://packagemanager.rstudio.com/all/__linux__/jammy/latest", getOption("repos")))
 
 install.packages("remotes")
 invisible(

--- a/server.R
+++ b/server.R
@@ -452,7 +452,7 @@ shinyServer(function(input, output, session) {
         schemaGenerator = schema_generator,
         metadataManifestPath = tmp_file_path,
         datasetId = selected$folder(),
-        manifest_record_type = "entity",
+        manifest_record_type = "table_and_file",
         restrict_manifest = FALSE,
         useSchemaLabel = FALSE, 
         hideBlanks = TRUE
@@ -490,7 +490,7 @@ shinyServer(function(input, output, session) {
         schemaGenerator = schema_generator,
         metadataManifestPath = tmp_file_path,
         datasetId = selected$folder(),
-        manifest_record_type = "entity",
+        manifest_record_type = "table_and_file",
         restrict_manifest = FALSE,
         useSchemaLabel = FALSE, 
         hideBlanks = TRUE


### PR DESCRIPTION
OK, I think deployment is fixed and we can at least generate templates. 
<img width="989" alt="image" src="https://github.com/nf-osi/NF_data_curator/assets/32753274/9641f4f2-9d28-469f-af4d-3b70411eed65">

Reviewers can go to https://sagebio.shinyapps.io/NF_data_curator-staging/ to do more tests with submission.

To recap, shinyapps updated their platform with a higher python version, so we updated to newer schematic that required higher python version anyway. However, this higher version is 23.6.3 and not yet 24.1.1 because there are other changes needed for 24.1.1 that I'll need to handle. So let's use 23.6.3 for now.
